### PR TITLE
Disabled companion automatically opening on self posts. Also fixed RES-related bug.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -382,7 +382,10 @@ chrome.extension.onRequest.addListener(function(request, sender, callback) {
   switch (request.action) {
     case 'thingClick':
       console.log('Thing clicked', request)
-      redditInfo.setURL(request.url, request.info)
+      if (request.info.domain == "self." + request.info.subreddit) {
+        console.log("Ignoring self post", request.info)
+      }
+      else redditInfo.setURL(request.url, request.info)
       break
   }
 })

--- a/src/redditContent.js
+++ b/src/redditContent.js
@@ -57,10 +57,6 @@ function thingClicked(e) {
 
   // Scrape the metadata.
   var info = scrapeThingInfo(el);
-  if (info.domain == "self." + info.subreddit) {
-    console.log("Ignoring self post.", info)
-    return
-  }
   if (info) {
     chrome.extension.sendRequest({action:'thingClick', url:a.href, info:info})
   }

--- a/src/redditContent.js
+++ b/src/redditContent.js
@@ -26,12 +26,14 @@ function scrapeThingInfo(thing) {
 
   info.score = parseInt(thing.querySelector('.score'+scoreClass).innerText)
   
-  info.subreddit = (thing.querySelector('a.subreddit') || document.querySelector('.redditname:first-child')).innerText
+  info.subreddit = (thing.querySelector('a.subreddit') || document.querySelector('.redditname > a')).innerText
 
   info.num_comments = parseInt(thing.querySelector('.comments').innerText) || 0
 
   info.permalink = thing.querySelector('.comments').href.match(/.*reddit.com(\/.+)/)[1]
-
+  
+  info.domain = thing.querySelector('.domain > a').innerText
+  
   console.log('Scraped info from page:', info)
   return info
 }
@@ -55,6 +57,10 @@ function thingClicked(e) {
 
   // Scrape the metadata.
   var info = scrapeThingInfo(el);
+  if (info.domain == "self." + info.subreddit) {
+    console.log("Ignoring self post.", info)
+    return
+  }
   if (info) {
     chrome.extension.sendRequest({action:'thingClick', url:a.href, info:info})
   }


### PR DESCRIPTION
Related discussion: http://www.reddit.com/r/companion/comments/ipopc/disable_companion_bar_on_self_posts/
# 

No longer automatically opens on self posts. You can still open by
clicking the companion icon.

Added domain attribute to info object.

Fixed bug where companion was getting the subreddit on browsers running
Reddit Enhancement Suite on some pages (was adding "+shortcut" to the end
of info.subreddit).
