### PR TITLE
Added option to not display message in notification

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -4,6 +4,7 @@ function initOptions() {
     'autoShowSelf': true,
     'showTooltips': true,
     'checkMail': true,
+    'notificationPrivacy': false
   }
 
   for (key in defaultOptions) {
@@ -368,8 +369,14 @@ mailNotifier = {
     var title, text
     if (newCount == 1) {
       var message = messages[newIdx]
-      title = message.data.author + ': ' + message.data.subject
-      text = message.data.body
+      if (localStorage['notificationPrivacy'] == 'true') {
+        title = 'reddit: new message!'
+        text = 'You have a new message.'
+      } else {
+        title = message.data.author + ': ' + message.data.subject
+        text = message.data.body
+      }
+      
     } else if (newCount > 1) {
       title = 'reddit: new messages!'
       text = 'You have ' + messages.length + ' new messages.'

--- a/src/options.html
+++ b/src/options.html
@@ -31,6 +31,7 @@
         <div class="options">
           <ul>
             <li><input type="checkbox" id="checkMail"> <label for="checkMail">display new message notifications</label></li>
+            <li><input type="checkbox" id="notificationPrivacy"> <label for="notificationPrivacy">hide the message contents in the notification</label></li>
           </ul>
         </div>
       </section>


### PR DESCRIPTION
When a new message is received, if the option is enabled, the contents
of the message are not displayed in the notification.

Requested via companion subreddit:
http://www.reddit.com/r/companion/comments/p6d7l/feature_request_ability_to_only_show_that_there/
