### PR TITLE
Workaround for wrong positioning of shine toolbar for image-only submissions

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -294,9 +294,9 @@ function addContent(tab, files, callback) {
         throw 'Invalid file extension.'
       }
 
-      inject(tab.id, fileInfo, function() {
-        injectNext()
-      })
+        inject(tab.id, fileInfo, function() {
+          injectNext()
+        })
     } else {
       console.log('Content injection took', Date.now() - startTime, 'ms')
       if (callback) { callback() }
@@ -323,7 +323,7 @@ tabStatus = {
   },
 
   ensureOverlay: function(tab) {
-    var needsOverlay = localStorage['allowHttps'] == 'true' && urlProtocol(tab.url) == 'https'
+    var needsOverlay = (localStorage['allowHttps'] == 'true' && urlProtocol(tab.url) == 'https') || urlProtocol(tab.url) == 'http'
     if (needsOverlay && !(tab.id in this.tabId) && !(tab.id in this.injecting)) {
       this.injecting[tab.id] = true
       addOverlayContent(tab)

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "reddit companion",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "manifest_version": 2,
   "description": "Turn your browser into a redditor's best friend.",
   "options_page": "options.html",

--- a/src/pageOverlay.js
+++ b/src/pageOverlay.js
@@ -15,11 +15,9 @@ function ShineOverlay(id) {
 ShineOverlay.prototype = {
   init: function() {
     this.frame = document.createElement('iframe')
-    this.frame.setAttribute('style', 'width:100%; height:100%; border:none; display:block !important; left:0; overflow:hidden;')
     this.frame.setAttribute('scrolling', 'no')
     this.frame.setAttribute('frameborder', 'no')
     this.overlay = document.createElement('shinebar')
-    this.overlay.setAttribute('style', 'position:fixed; top:0; left:0; right:0; height:0; display:block; height:30px; background:-webkit-linear-gradient(90deg, rgba(222,222,222,.93), rgba(245,245,245,.93)); border-bottom:1px solid #777; box-shadow:0 2px 1px rgba(100,100,100,.25); z-index:2147483647; overflow:hidden;')
     this.overlay.appendChild(this.frame)
     // document.documentElement.appendChild(this.overlay)
     document.documentElement.insertBefore(this.overlay, document.documentElement.firstChild)

--- a/src/pageOverlay.js
+++ b/src/pageOverlay.js
@@ -15,11 +15,14 @@ function ShineOverlay(id) {
 ShineOverlay.prototype = {
   init: function() {
     this.frame = document.createElement('iframe')
+    this.frame.setAttribute('style', 'width:100%; height:100%; border:none; display:block !important; left:0; overflow:hidden;')
     this.frame.setAttribute('scrolling', 'no')
     this.frame.setAttribute('frameborder', 'no')
     this.overlay = document.createElement('shinebar')
+    this.overlay.setAttribute('style', 'position:fixed; top:0; left:0; right:0; height:0; display:block; height:30px; background:-webkit-linear-gradient(90deg, rgba(222,222,222,.93), rgba(245,245,245,.93)); border-bottom:1px solid #777; box-shadow:0 2px 1px rgba(100,100,100,.25); z-index:2147483647; overflow:hidden;')
     this.overlay.appendChild(this.frame)
-    document.documentElement.appendChild(this.overlay)
+    // document.documentElement.appendChild(this.overlay)
+    document.documentElement.insertBefore(this.overlay, document.documentElement.firstChild)
   },
 
   setHeight: function(height) {


### PR DESCRIPTION
As detailed [here](http://redd.it/16mbxk), when loading an image-only post from Chrome 24, CSS is not injected into the dummy html page that Chrome creates to wrap the image in. This workaround manually injects the relevant styles as inline style attributes in the shinebar and iframe elements. Also, for good measure, the shinebar is injected at the start of the document body instead of at the end.
