### PR TITLE
allow the "show reddit information" button to appear on https websites

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+== Version 1.1.3 ==
+* Add HTTPS domains.
+
 == Version 1.1.2 ==
 * Fix display issue on image pages.
 

--- a/src/background.js
+++ b/src/background.js
@@ -434,7 +434,7 @@ mailChecker = {
 }
 
 function setPageActionIcon(tab) {
-  if (/^http:\/\/.*/.test(tab.url)) {
+  if (/^https?:\/\/.*/.test(tab.url)) {
     var info = redditInfo.getURL(tab.url)
     if (info) {
       chrome.pageAction.setIcon({tabId:tab.id, path:'/images/reddit.png'})

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,15 +1,16 @@
 {
   "name": "reddit companion",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "manifest_version": 2,
   "description": "Turn your browser into a redditor's best friend.",
   "options_page": "options.html",
   "permissions": [
     "tabs",
     "notifications",
-    "http://*/*"
+    "http://*/*",
+    "https://*/*"
   ],
-  "content_security_policy": "default-src 'self'; connect-src 'self' http://www.reddit.com",
+  "content_security_policy": "default-src 'self'; connect-src 'self' http://www.reddit.com; style-src 'self' 'unsafe-inline'; script-src 'self'",
   "icons": {
     "16"  : "images/shine-16.png",
     "48"  : "images/shine-48.png",
@@ -29,7 +30,7 @@
       "js": ["debug.js", "redditContent.js"]
     },
     {
-      "matches": ["http://*/*"],
+      "matches": ["http://*/*", "https://*/*"],
       "run_at": "document_start",
       "js": ["debug.js", "pageOverlay.js"]
     }


### PR DESCRIPTION
This enables the background.js reddit information function to run on https
domains.  I updated the permissions in the manifest, and there is currently
a bug in webkit which requires the style-src 'unsafe-inline' directive.

See here: https://bugs.webkit.org/show_bug.cgi?id=112270
