### PR TITLE
Subreddit styles tweak.

### DIFF
--- a/src/pageOverlay.js
+++ b/src/pageOverlay.js
@@ -32,6 +32,7 @@ ShineOverlay.prototype = {
       this.overlay.style.height = height
     }
     document.documentElement.style.marginTop = height
+    document.documentElement.style.position = 'relative'
     this.overlay.style.opacity = height ? 1 : 0
   },
 
@@ -72,6 +73,7 @@ function removeBar() {
     shineBar.remove()
     shineBar = false
     console.log('Shine bar removed.')
+    document.documentElement.style.position = ''
   }
 }
 


### PR DESCRIPTION
Users with the bar enabled in self posts may see some absolutely
positioned content, eg stickies/announcements, displaced by the
equivalent amount of top margin applied to `html`, often
hiding/obscuring it.
