### PR TITLE
added padding to close button (OSX scrollbar fix)

### DIFF
--- a/src/bar.css
+++ b/src/bar.css
@@ -36,6 +36,6 @@ input#title-input { -webkit-box-flex:1; background:-webkit-gradient(linear, left
 input#title-input:focus { outline:none; box-shadow:0 0 4px rgba(0,0,0,1); }
 input#title-input::-webkit-input-placeholder { color:#555; }
 
-#close { background:none; padding:0; margin-right:6px; box-shadow:none; border-radius:2px; opacity:.5; }
+#close { background:none; padding:0 6px; margin-right:6px; box-shadow:none; border-radius:2px; opacity:.5; }
 #close img { margin-top:3px; }
 #close:hover { opacity:.75; }


### PR DESCRIPTION
original issue was #43, but that PR is quite ugly by this point. The main issue is that the scrollbar on OSX frequently covers the close button. This PR adds 12px of total horizontal padding so the button is not covered.
