### PR TITLE
Strip off '/r/' when scraping subreddit name.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+== Version 1.1.3 ==
+* Adjust subreddit name scraping to account for reddit.com change.
+
 == Version 1.1.2 ==
 * Fix display issue on image pages.
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "reddit companion",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "manifest_version": 2,
   "description": "Turn your browser into a redditor's best friend.",
   "options_page": "options.html",

--- a/src/redditContent.js
+++ b/src/redditContent.js
@@ -26,7 +26,7 @@ function scrapeThingInfo(thing) {
 
   info.score = parseInt(thing.querySelector('.score'+scoreClass).innerText)
   
-  info.subreddit = (thing.querySelector('a.subreddit') || document.querySelector('.redditname > a')).innerText
+  info.subreddit = (thing.querySelector('a.subreddit') || document.querySelector('.redditname > a')).innerText.replace('/r/','')
 
   info.num_comments = parseInt(thing.querySelector('.comments').innerText) || 0
 


### PR DESCRIPTION
The change adding the '/r/' to the subreddit link on the front page resulted in companion displaying subreddits as '/r//r/subreddit', when linking from the front page.

:eyeglasses: @chromakode
